### PR TITLE
Bring the TLE backend to parity with the current stapi-spec

### DIFF
--- a/stapi_fastapi_tle/backend.py
+++ b/stapi_fastapi_tle/backend.py
@@ -92,8 +92,8 @@ class StapiMockBackend:
         except IndexError:
             alt = 0
         passes = self.satellite.passes(
-            start=validated.properties.datetime[0],
-            end=validated.properties.datetime[1],
+            start=validated.datetime[0],
+            end=validated.datetime[1],
             lon=validated.geometry.coordinates[0],
             lat=validated.geometry.coordinates[1],
             alt=alt,

--- a/stapi_fastapi_tle/models.py
+++ b/stapi_fastapi_tle/models.py
@@ -11,7 +11,7 @@ from pydantic import (
 )
 
 from stapi_fastapi.models.constraints import Constraints as BaseConstraints
-from stapi_fastapi.models.opportunity import OpportunityRequest
+from stapi_fastapi.models.opportunity import OpportunityRequest, OpportunityProperties
 
 
 class Satellite(BaseModel):
@@ -33,10 +33,7 @@ class Satellite(BaseModel):
         return self.tle.split("\n")
 
 
-class PassProperties(BaseModel):
-    datetime: AwareDatetime
-    start: AwareDatetime
-    end: AwareDatetime
+class PassProperties(OpportunityProperties):
     view_off_nadir: float = Field(..., alias="view:off_nadir")
     view_azimuth: float = Field(..., alias="view:azimuth")
     view_elevation: float = Field(..., alias="view:elevation")

--- a/stapi_fastapi_tle/satellite.py
+++ b/stapi_fastapi_tle/satellite.py
@@ -59,7 +59,10 @@ class EarthObservationSatelliteModel(EarthSatellite):
                         bbox=[lon, lat, alt, lon, lat, alt],
                     ),
                     properties={
-                        "datetime": [t.utc_datetime(), t.utc_datetime()],
+                        "datetime": [
+                            t.utc_datetime() - self._model.block_time[0], 
+                            t.utc_datetime() + self._model.block_time[1]
+                        ],
                         "start": t.utc_datetime() - self._model.block_time[0],
                         "end": t.utc_datetime() + self._model.block_time[1],
                         "view:off_nadir": off_nadir,

--- a/stapi_fastapi_tle/satellite.py
+++ b/stapi_fastapi_tle/satellite.py
@@ -59,7 +59,7 @@ class EarthObservationSatelliteModel(EarthSatellite):
                         bbox=[lon, lat, alt, lon, lat, alt],
                     ),
                     properties={
-                        "datetime": t.utc_datetime(),
+                        "datetime": [t.utc_datetime(), t.utc_datetime()],
                         "start": t.utc_datetime() - self._model.block_time[0],
                         "end": t.utc_datetime() + self._model.block_time[1],
                         "view:off_nadir": off_nadir,
@@ -67,6 +67,7 @@ class EarthObservationSatelliteModel(EarthSatellite):
                         "view:elevation": elevation.degrees,
                         "sun:elevation": 0,
                         "sun:azimuth": 0,
+                        "product_id": "mock:standard",
                     },
                 )
             )


### PR DESCRIPTION
This PR aims to fixup the TLE backend so the opportunities endpoint returns values successfully.

The specific changes include updating the `PassProperties` model to inherit from the correct base class, hoisting some properties from the request, adding `produt_id` to the response, and generally providing a shape that will pass validation.